### PR TITLE
Respect input source maps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,29 @@
 const babel = require("@babel/core");
 
 module.exports = {
-  process(src) {
+  process(src, filename, transformOptions) {
     const options = {
       babelrc: false,
       compact: false,
-      plugins: [require.resolve("@babel/plugin-transform-modules-commonjs")]
+      plugins: [require.resolve("@babel/plugin-transform-modules-commonjs")],
+      // Ensures that babel respects original source maps. This allows to use
+      // already transpiled JavaScript source code and enables correct stack
+      // traces when tests fail. 
+      inputSourceMap: true,
+
+      // To make sure filenames are accurate
+      filename: filename,
+      cwd: transformOptions.cwd,
     };
 
-    return babel.transform(src, options).code;
+    const transformResult = babel.transform(src, options);
+    if (transformResult) {
+      const { code, map } = transformResult;
+      if (typeof code === 'string') {
+        return { code, map };
+      }
+    }
+
+    return src;
   }
 };


### PR DESCRIPTION
This PR borrows business logic from https://github.com/facebook/jest/blob/master/packages/babel-jest/src/index.ts#L227 babel-jest transformer and uses the same approach to emit source maps. This in turn enables correct stack traces and allows to use this plugin on a transpiled JavaScript. For example, we can use transpiled TypeScript to run tests and get correct errors pointing to TypeScript file.